### PR TITLE
Disable crud for non club owner

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,9 @@ class EventsController < ApplicationController
   # GET /events/new
   def new
     @event = Event.new
+    @club = Club.find(params[:club]) if params[:club].present?
+    
+    
     authorize @event
   end
 
@@ -78,6 +81,6 @@ class EventsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def event_params
-      params.require(:event).permit(:name, :address, :city, :postal_code, :website, :image_url, :start_date, :end_date, :sport_id)
+      params.require(:event).permit(:name, :address,:club_id,  :city, :postal_code, :website, :image_url, :start_date, :end_date, :sport_id)
     end
 end

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -61,9 +61,13 @@
     <div class="text-bold">
     </div>
   </div>
+  <%=  %>
   <div class="col-span-2 row-start-4">
+  <% if current_user %>
     <%= link_to 'Edit', edit_club_path(@club) %> |
+    <%= link_to 'Add an Event', new_event_path(club: @club) %> |
     <%= link_to 'Back', clubs_path %>
+  <% end  %>
   </div>
 </div>
 

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -63,7 +63,7 @@
   </div>
   <%=  %>
   <div class="col-span-2 row-start-4">
-  <% if current_user %>
+  <% if current_user && @club.admin == current_user%>
     <%= link_to 'Edit', edit_club_path(@club) %> |
     <%= link_to 'Add an Event', new_event_path(club: @club) %> |
     <%= link_to 'Back', clubs_path %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: event) do |form| %>
   <%= render "shared/error_messages", resource: form.object %>
-
+  <%= form.hidden_field(:club_id, value: "#{@club.id}") if @club %>
   <div class="form-group">
     <%= form.label :name %>
     <%= form.text_field :name, class: "form-control" %>


### PR DESCRIPTION
A user can now only edit and add en event if he is club admin to avoid unauthorized error from pundit.
NS: allow to duplicate address if event is the same address as the club